### PR TITLE
Prefix sum implementation WIP

### DIFF
--- a/compute-shader-hello/src/main.rs
+++ b/compute-shader-hello/src/main.rs
@@ -22,8 +22,13 @@ use wgpu::util::DeviceExt;
 
 use bytemuck;
 
-const N_DATA: usize = 16384;
+const N_DATA: usize = 1024;
 const WG_SIZE: usize = 16;
+
+// Verify that the data is OEIS A000217
+fn verify(data: &[u32]) -> bool {
+    data.iter().enumerate().all(|(i, val)| (i * (i + 1)) / 2 == *val as usize)
+}
 
 async fn run() {
     let instance = wgpu::Instance::new(wgpu::Backends::PRIMARY);
@@ -141,7 +146,7 @@ async fn run() {
     if buf_future.await.is_ok() {
         let data_raw = &*buf_slice.get_mapped_range();
         let data: &[u32] = bytemuck::cast_slice(data_raw);
-        println!("data: {:?}", &*data);
+        println!("results correct: {}", verify(data));
     }
     if features.contains(wgpu::Features::TIMESTAMP_QUERY) {
         let ts_period = queue.get_timestamp_period();

--- a/compute-shader-hello/src/main.rs
+++ b/compute-shader-hello/src/main.rs
@@ -22,8 +22,8 @@ use wgpu::util::DeviceExt;
 
 use bytemuck;
 
-const N_DATA: usize = 1024;
-const WG_SIZE: usize = 16;
+const N_DATA: usize = 65536;
+const WG_SIZE: usize = 1024;
 
 // Verify that the data is OEIS A000217
 fn verify(data: &[u32]) -> bool {

--- a/compute-shader-hello/src/main.rs
+++ b/compute-shader-hello/src/main.rs
@@ -22,6 +22,9 @@ use wgpu::util::DeviceExt;
 
 use bytemuck;
 
+const N_DATA: usize = 16384;
+const WG_SIZE: usize = 16;
+
 async fn run() {
     let instance = wgpu::Instance::new(wgpu::Backends::PRIMARY);
     let adapter = instance.request_adapter(&Default::default()).await.unwrap();
@@ -30,7 +33,7 @@ async fn run() {
         .request_device(
             &wgpu::DeviceDescriptor {
                 label: None,
-                features: features & wgpu::Features::TIMESTAMP_QUERY,
+                features: features & (wgpu::Features::TIMESTAMP_QUERY | wgpu::Features::CLEAR_COMMANDS),
                 limits: Default::default(),
             },
             None,
@@ -54,8 +57,8 @@ async fn run() {
         source: wgpu::ShaderSource::Wgsl(include_str!("shader.wgsl").into()),
     });
     println!("shader compilation {:?}", start_instant.elapsed());
-    let input_f = &[1.0f32, 2.0f32];
-    let input : &[u8] = bytemuck::bytes_of(input_f);
+    let input_f: Vec<u32> = (0..N_DATA as u32).collect();
+    let input: &[u8] = bytemuck::cast_slice(&input_f);
     let input_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
         label: None,
         contents: input,
@@ -67,6 +70,15 @@ async fn run() {
         label: None,
         size: input.len() as u64,
         usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+    const N_WG: usize = N_DATA / WG_SIZE;
+    const STATE_SIZE: usize = N_WG * 3 + 1;
+    // TODO: round this up
+    let state_buf = device.create_buffer(&wgpu::BufferDescriptor {
+        label: None,
+        size: 4 * STATE_SIZE as u64,
+        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
         mapped_at_creation: false,
     });
     // This works if the buffer is initialized, otherwise reads all 0, for some reason.
@@ -87,21 +99,28 @@ async fn run() {
     let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
         label: None,
         layout: &bind_group_layout,
-        entries: &[wgpu::BindGroupEntry {
-            binding: 0,
-            resource: input_buf.as_entire_binding(),
-        }],
+        entries: &[
+            wgpu::BindGroupEntry {
+                binding: 0,
+                resource: input_buf.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 1,
+                resource: state_buf.as_entire_binding(),
+            },
+        ],
     });
 
     let mut encoder = device.create_command_encoder(&Default::default());
     if let Some(query_set) = &query_set {
         encoder.write_timestamp(query_set, 0);
     }
+    encoder.clear_buffer(&state_buf, 0, None);
     {
         let mut cpass = encoder.begin_compute_pass(&Default::default());
         cpass.set_pipeline(&pipeline);
         cpass.set_bind_group(0, &bind_group, &[]);
-        cpass.dispatch(input_f.len() as u32, 1, 1);
+        cpass.dispatch(N_WG as u32, 1, 1);
     }
     if let Some(query_set) = &query_set {
         encoder.write_timestamp(query_set, 1);
@@ -121,14 +140,17 @@ async fn run() {
     println!("post-poll {:?}", std::time::Instant::now());
     if buf_future.await.is_ok() {
         let data_raw = &*buf_slice.get_mapped_range();
-        let data : &[f32] = bytemuck::cast_slice(data_raw);
+        let data: &[u32] = bytemuck::cast_slice(data_raw);
         println!("data: {:?}", &*data);
     }
     if features.contains(wgpu::Features::TIMESTAMP_QUERY) {
         let ts_period = queue.get_timestamp_period();
         let ts_data_raw = &*query_slice.get_mapped_range();
-        let ts_data : &[u64] = bytemuck::cast_slice(ts_data_raw);
-        println!("compute shader elapsed: {:?}ms", (ts_data[1] - ts_data[0]) as f64 * ts_period as f64 * 1e-6);
+        let ts_data: &[u64] = bytemuck::cast_slice(ts_data_raw);
+        println!(
+            "compute shader elapsed: {:?}ms",
+            (ts_data[1] - ts_data[0]) as f64 * ts_period as f64 * 1e-6
+        );
     }
 }
 

--- a/compute-shader-hello/src/shader.wgsl
+++ b/compute-shader-hello/src/shader.wgsl
@@ -34,15 +34,15 @@ let FLAG_NOT_READY = 0u;
 let FLAG_AGGREGATE_READY = 1u;
 let FLAG_PREFIX_READY = 2u;
 
-let workgroup_size: u32 = 256u;
-let N_SEQ = 4u;
+let workgroup_size: u32 = 512u;
+let N_SEQ = 8u;
 
 var<workgroup> part_id: u32;
 var<workgroup> scratch: array<u32, workgroup_size>;
 var<workgroup> shared_prefix: u32;
 var<workgroup> shared_flag: u32;
 
-[[stage(compute), workgroup_size(256)]]
+[[stage(compute), workgroup_size(512)]]
 fn main([[builtin(local_invocation_id)]] local_id: vec3<u32>) {
     if (local_id.x == 0u) {
         part_id = atomicAdd(&state_buf.state[0], 1u);
@@ -59,7 +59,7 @@ fn main([[builtin(local_invocation_id)]] local_id: vec3<u32>) {
     }
     scratch[local_id.x] = el;
     // This must be lg2(workgroup_size)
-    for (var i: u32 = 0u; i < 8u; i = i + 1u) {
+    for (var i: u32 = 0u; i < 9u; i = i + 1u) {
         workgroupBarrier();
         if (local_id.x >= (1u << i)) {
             el = el + scratch[local_id.x - (1u << i)];

--- a/compute-shader-hello/src/shader.wgsl
+++ b/compute-shader-hello/src/shader.wgsl
@@ -71,16 +71,16 @@ fn main([[builtin(local_invocation_id)]] local_id: vec3<u32>) {
 
     var flag = FLAG_AGGREGATE_READY;
     if (local_id.x == workgroup_size - 1u) {
-        state_buf.state[my_part_id * 3u + 2u] = el;
+        atomicStore(&state_buf.state[my_part_id * 3u + 2u], el);
         if (my_part_id == 0u) {
-            state_buf.state[my_part_id * 3u + 3u] = el;
+            atomicStore(&state_buf.state[my_part_id * 3u + 3u], el);
             flag = FLAG_PREFIX_READY;
         }
     }
     // make sure these barriers are in uniform control flow
     storageBarrier();
     if (local_id.x == workgroup_size - 1u) {
-        state_buf.state[my_part_id * 3u + 1u] = flag;
+        atomicStore(&state_buf.state[my_part_id * 3u + 1u], flag);
     }
 
     if (my_part_id != 0u) {
@@ -113,11 +113,11 @@ fn main([[builtin(local_invocation_id)]] local_id: vec3<u32>) {
         if (local_id.x == workgroup_size - 1u) {
             let inclusive_prefix = exclusive_prefix + el;
             shared_prefix = exclusive_prefix;
-            state_buf.state[my_part_id * 3u + 3u] = inclusive_prefix;
+            atomicStore(&state_buf.state[my_part_id * 3u + 3u], inclusive_prefix);
         }
         storageBarrier();
         if (local_id.x == workgroup_size - 1u) {
-            state_buf.state[my_part_id * 3u + 1u] = FLAG_PREFIX_READY;
+            atomicStore(&state_buf.state[my_part_id * 3u + 1u], FLAG_PREFIX_READY);
         }
     }
     var prefix = 0u;


### PR DESCRIPTION
This is a draft, I'm still working on it. I'll likely create another subdirectory for tests and add this to that, as overwriting the main hello example is not very good form. But I'm doing it for expedience.

The version at tip of tree as I write this (87e5b20) works well on AMD 5700 XT. In fact, it works *very* well - I'm seeing 36.4 billion elements/s, which is excellent. It's within a sliver of a compute shader that just copies input to output, and looking at GPU counters suggests that memory bandwidth is pretty well saturated.

This version also makes some progress on each spin, so does not depend on strong forward progress guarantees from the GPU.

That said, I am employing the atomicOr workaround for the atomic bugs I'm seeing, otherwise I get both incorrect results and hangs (try N_DATA = 1 << 17 for a nice mix of the two). I will probably work on a simplified version of the test to exercise the atomic problems without bringing in all of the complexity of full prefix sum.